### PR TITLE
Always set commit/author time to epoch

### DIFF
--- a/src/high_level.rs
+++ b/src/high_level.rs
@@ -99,7 +99,7 @@ impl GitRepository {
         let commit_user = CommitUserInfo {
             name,
             email,
-            time: time::OffsetDateTime::now_utc(),
+            time: time::OffsetDateTime::UNIX_EPOCH,
         };
 
         let commit = PackFileEntry::Commit(Commit {


### PR DESCRIPTION
If the contents of the tree have not changed, we don't want cargo update to fetch anything. This requires the commit in the packfile to remain stable.